### PR TITLE
Fix public review banner directory and add translation banner

### DIFF
--- a/website/i18n/ja/docusaurus-plugin-content-docs/translated/stylus/reference/rust-sdk-guide.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/translated/stylus/reference/rust-sdk-guide.md
@@ -9,7 +9,11 @@ sidebar_position: 1
 target_audience: Developers using the Stylus Rust SDK to write and deploy smart contracts.
 ---
 
-import PublicPreviewBannerPartial from '../partials/_stylus-public-preview-banner.md';
+import TranslationBannerPartial from "./partials/_stylus-translation-banner-partial.md";
+
+import PublicPreviewBannerPartial from './partials/_stylus-public-preview-banner-partial.md';
+
+<TranslationBannerPartial />
 
 <PublicPreviewBannerPartial />
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/translated/stylus/reference/stylus-sdk.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/translated/stylus/reference/stylus-sdk.md
@@ -9,7 +9,11 @@ sidebar_label: 'Stylus SDK レポジトリ'
 sidebar_position: 2
 ---
 
-import PublicPreviewBannerPartial from '../partials/_stylus-public-preview-banner.md';
+import TranslationBannerPartial from "./partials/_stylus-translation-banner-partial.md";
+
+import PublicPreviewBannerPartial from './partials/_stylus-public-preview-banner-partial.md';
+
+<TranslationBannerPartial />
 
 <PublicPreviewBannerPartial />
 

--- a/website/i18n/ja/docusaurus-plugin-content-docs/translated/stylus/reference/testnet-information.md
+++ b/website/i18n/ja/docusaurus-plugin-content-docs/translated/stylus/reference/testnet-information.md
@@ -9,7 +9,11 @@ sidebar_label: 'テストネット情報'
 sidebar_position: 9
 ---
 
-import PublicPreviewBannerPartial from '../partials/_stylus-public-preview-banner.md';
+import TranslationBannerPartial from "./partials/_stylus-translation-banner-partial.md";
+
+import PublicPreviewBannerPartial from './partials/_stylus-public-preview-banner-partial.md';
+
+<TranslationBannerPartial />
 
 <PublicPreviewBannerPartial />
 


### PR DESCRIPTION

Add translation banner, and changed public preview banner directory for the following files:
- `rust-sdk-guide.md`
- `stylus-sdk.md`
- `testnet-information.md`